### PR TITLE
Fetching to calendar added, calendar split into components

### DIFF
--- a/src/api/houseInfo.ts
+++ b/src/api/houseInfo.ts
@@ -1,4 +1,4 @@
-import { CleaningTask, Bills, HouseInfo } from 'types/types';
+import { usersCleaningTask, CleaningTask, Bills, HouseInfo } from 'types/types';
 
 export const fetchCleaningTasks = async (): Promise<CleaningTask[]> => {
   const token = localStorage.getItem('token');
@@ -57,6 +57,53 @@ export const fetchHouseInfo = async (): Promise<HouseInfo> => {
     throw new Error('Failed to fetch house info: ' + (json.message || 'Unknown error'));
 
   return json.data as HouseInfo;
+};
+
+export const fetchSingleUserTask = async (): Promise<usersCleaningTask[]> => {
+  const token = localStorage.getItem('token');
+  if (!token) throw new Error('No auth token found');
+
+  const res = await fetch('http://localhost:5000/api/fetch-cleaning-user', {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!res.ok) {
+    const errorText = await res.text();
+    throw new Error(`Failed to fetch cleaning tasks: ${res.status} ${errorText}`);
+  }
+
+  const json = await res.json();
+
+  if (!json.success) {
+    throw new Error(`Failed to fetch tasks: ${json.message || 'Unknown error'}`);
+  }
+
+  return json.data as usersCleaningTask[];
+};
+
+export const updateTaskStatus = async (taskId: string, taskComplete: boolean): Promise<void> => {
+  const token = localStorage.getItem('token');
+  if (!token) throw new Error('No auth token found');
+
+  const res = await fetch('http://localhost:5000/api/update-cleaning-user', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      cleaning_task_id: taskId,
+      task_complete: taskComplete,
+    }),
+  });
+
+  if (!res.ok) {
+    const errorBody = await res.json();
+    throw new Error(errorBody.error || 'Failed to update task status');
+  }
 };
 
 //export const fetchTestDbData = async () => {

--- a/src/pages/Dashboard/Calendar.tsx
+++ b/src/pages/Dashboard/Calendar.tsx
@@ -1,17 +1,18 @@
-const Calendar = () => {
-  const daysOfTheWeek: string[] = [
-    'SUNDAY',
-    'MONDAY',
-    'TUESDAY',
-    'WEDNESDAY',
-    'THURSDAY',
-    'FRIDAY',
-    'SATURDAY',
-  ];
+import React, { useEffect, useState } from 'react';
+import { fetchSingleUserTask } from '../../api/houseInfo.ts';
+import { updateTaskStatus } from '../../api/houseInfo.ts';
+import CalendarCleaningTaskList from './CalendarCleaningTaskList.tsx';
+import { usersCleaningTask } from '../../types/types.ts';
 
-  const monthsOfTheYear: string[] = [
+const Calendar = () => {
+  const [tasks, setTasks] = useState<usersCleaningTask[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const today = new Date();
+  const days = ['SUNDAY', 'MONDAY', 'TUESDAY', 'WEDNESDAY', 'THURSDAY', 'FRIDAY', 'SATURDAY'];
+  const months = [
     'JANUARY',
-    'FEBRUAY',
+    'FEBRUARY',
     'MARCH',
     'APRIL',
     'MAY',
@@ -24,66 +25,55 @@ const Calendar = () => {
     'DECEMBER',
   ];
 
-  const today = new Date();
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const data = await fetchSingleUserTask();
+        setTasks(data);
+      } catch (e) {
+        console.error('Error:', e);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  const handleToggle = async (taskId: string, currentStatus: boolean) => {
+    try {
+      await updateTaskStatus(taskId, !currentStatus);
+      setTasks((prev) =>
+        prev.map((task) =>
+          task.cleaning_task_id === taskId ? { ...task, task_complete: !currentStatus } : task
+        )
+      );
+    } catch (e) {
+      console.error('Failed to update status:', e);
+    }
+  };
 
   return (
     <div className="calendar-container">
-      <div className="string-left"></div>
-      <div className="string-right"></div>
-      <div className="pin calendar-pin"></div>
+      <div className="string-left" />
+      <div className="string-right" />
+      <div className="pin calendar-pin" />
       <div className="calendar">
         <div className="date-container">
-          <div className="date-display">{daysOfTheWeek[today.getDay()]}</div>
-          <div className="date-display">
-            {today.getDate() < 10 ? 0 : today.getDate() < 20 ? 1 : today.getDate() < 30 ? 2 : 3}
-          </div>
-          <div className="date-display">{today.getDate() % 10}</div>
-          <div className="date-display">{monthsOfTheYear[today.getMonth()]}</div>
+          <div className="date-display">{days[today.getDay()]}</div>
+          <div className="date-display">{today.getDate()}</div>
+          <div className="date-display">{months[today.getMonth()]}</div>
         </div>
+
         <div
           className="image-container"
           style={{
-            backgroundImage: `url(/calendar_photos/${monthsOfTheYear[today.getMonth()].toLowerCase()}.png)`,
+            backgroundImage: `url(/calendar_photos/${months[today.getMonth()].toLowerCase()}.png)`,
           }}
         ></div>
+
         <div className="information">
           <h1 className="heading">My Cleaning Tasks:</h1>
-          <div className="task-container">
-            <div className="task">
-              <label className="task-name" htmlFor="task1">
-                TASK 1
-              </label>
-              <input type="checkbox" id="task1" name="task1" value="Task 1" />
-            </div>
-            <div className="task">
-              <label className="task-name" htmlFor="task2">
-                TASK 2
-              </label>
-              <input type="checkbox" id="task2" name="task2" value="Task 2" />
-            </div>
-          </div>
-
-          <h1 className="heading">My Bills:</h1>
-          <div className="task-container">
-            <div className="task">
-              <label className="task-name" htmlFor="bill1">
-                BILL 1
-              </label>
-              <input type="checkbox" id="bill1" name="bill1" value="Bill 1" />
-            </div>
-            <div className="task">
-              <label className="task-name" htmlFor="bill2">
-                BILL 2
-              </label>
-              <input type="checkbox" id="bill2" name="bill2" value="Bill 2" />
-            </div>
-            <div className="task">
-              <label className="task-name" htmlFor="bill3">
-                BILL 3
-              </label>
-              <input type="checkbox" id="bill3" name="bill3" value="Bill 3" />
-            </div>
-          </div>
+          <CalendarCleaningTaskList tasks={tasks} loading={loading} onToggle={handleToggle} />
 
           <h1 className="heading">Review Submission:</h1>
           <form className="review-form">

--- a/src/pages/Dashboard/CalendarCleaningTaskItem.tsx
+++ b/src/pages/Dashboard/CalendarCleaningTaskItem.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { usersCleaningTask } from '../../types/types.ts';
+
+interface Props {
+  task: usersCleaningTask;
+  onToggle: (taskId: string, currentStatus: boolean) => void;
+}
+
+const CleaningTaskItem: React.FC<Props> = ({ task, onToggle }) => (
+  <div className="task">
+    <label className="task-name" htmlFor={task.cleaning_task_id}>
+      {task.description}
+    </label>
+    <input
+      type="checkbox"
+      id={task.cleaning_task_id}
+      checked={task.task_complete ?? false}
+      onChange={() => onToggle(task.cleaning_task_id, task.task_complete ?? false)}
+    />
+  </div>
+);
+
+export default CleaningTaskItem;

--- a/src/pages/Dashboard/CalendarCleaningTaskList.tsx
+++ b/src/pages/Dashboard/CalendarCleaningTaskList.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import { usersCleaningTask } from '../../types/types.ts';
+import CalendarCleaningTaskItem from './CalendarCleaningTaskItem.tsx';
+
+interface Props {
+  tasks: usersCleaningTask[];
+  onToggle: (taskId: string, currentStatus: boolean) => void;
+  loading: boolean;
+}
+
+const CalendarCleaningTaskList: React.FC<Props> = ({ tasks, onToggle, loading }) => {
+  if (loading) return <p>Loading tasks...</p>;
+  if (tasks.length === 0) return <p>No cleaning tasks assigned.</p>;
+
+  return (
+    <div className="task-container">
+      {tasks.map((task) => (
+        <CalendarCleaningTaskItem key={task.cleaning_task_id} task={task} onToggle={onToggle} />
+      ))}
+    </div>
+  );
+};
+
+export default CalendarCleaningTaskList;

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -7,6 +7,11 @@ export interface CleaningTask {
   task_complete?: boolean;
   created_at?: string;
 }
+export interface usersCleaningTask {
+  cleaning_task_id: string;
+  description: string;
+  task_complete?: boolean;
+}
 
 export interface Bills {
   bill_id: string;


### PR DESCRIPTION
## 📌 Summary

![image](https://github.com/user-attachments/assets/7792ced2-0459-470f-947f-32b90c0e5b4b)


Implemented user-specific cleaning task retrieval:

Created fetchSingleUserCleaningTasks controller to query tasks by assigned_to_user.
Protected route with authentication middleware.
Added frontend fetch (fetchSingleUserTask) using token-based authorization.
Integrated calendar UI with backend:
Refactored Calendar.tsx to fetch and display cleaning tasks upon mount.

Created modular components:

CalendarCleaningTaskItem.tsx: individual task checkbox item.
CalendarCleaningTaskList.tsx: renders list of user tasks.

Added task completion update logic:

Created UpdateTaskStatusSchema and updateCleaningTaskStatus controller to mark tasks complete/incomplete.
Hooked up checkbox interaction to POST updates to the database.
Updated frontend state based on API response.